### PR TITLE
Add links to website

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,5 @@
 class Link < ApplicationRecord
   belongs_to :website
-  
+
   validates :href, :text, presence: true
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,5 @@
+class Link < ApplicationRecord
+  belongs_to :website
+  
+  validates :href, :text, presence: true
+end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -2,6 +2,8 @@ class Website < ApplicationRecord
   validates :url, presence: true
   validate  :url_valid?
 
+  has_many :links, dependent: :destroy
+
   private
 
   def url_valid?

--- a/app/services/website_scraper.rb
+++ b/app/services/website_scraper.rb
@@ -11,13 +11,28 @@ class WebsiteScraper
     if @url_validator.valid?(website.url)
       page = @driver.get(website.url)
       fill_in_title(page)
+      fill_in_links(page)
     end
     website
   end
 
   private
 
+  def link_adapter_class
+    WebsiteScraper::LinkAdapter
+  end
+
   def fill_in_title(page)
     website.title = page.title
+  end
+
+  def fill_in_links(page)
+    page.links.each do |page_link|
+      link = link_adapter_class.new(page_link)
+      website.links.build(
+        text: link.text,
+        href: link.href
+      )
+    end
   end
 end

--- a/app/services/website_scraper/link_adapter.rb
+++ b/app/services/website_scraper/link_adapter.rb
@@ -1,0 +1,27 @@
+class WebsiteScraper
+  class LinkAdapter
+    def initialize(page_link)
+      @page_link = page_link
+    end
+
+    def text
+      relevant_link_text
+    end
+
+    def href
+      @page_link.resolved_uri.to_s
+    rescue Mechanize::UnsupportedSchemeError
+      @page_link.uri.to_s
+    end
+
+    private
+
+    def relevant_link_text
+      if @page_link.text.strip.blank?
+        href
+      else
+        @page_link.text
+      end
+    end
+  end
+end

--- a/app/views/api/v1/websites/_links.json.jbuilder
+++ b/app/views/api/v1/websites/_links.json.jbuilder
@@ -1,0 +1,2 @@
+json.text link.text
+json.href link.href

--- a/app/views/api/v1/websites/index.json.jbuilder
+++ b/app/views/api/v1/websites/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.websites @websites do |website|
+  json.title website.title
+  json.url   website.url
+
+  json.links website.links, partial: 'links', as: :link
+end

--- a/app/views/websites/_link.html.erb
+++ b/app/views/websites/_link.html.erb
@@ -1,0 +1,1 @@
+<%= link_to link.text, link.href, target: :_blank %>

--- a/app/views/websites/_website.html.erb
+++ b/app/views/websites/_website.html.erb
@@ -1,7 +1,14 @@
-<%= link_to website.title, website_path(website) if website.title %>
-|
-<%= link_to website.url, website.url, target: :_blank %>
-|
-<%= link_to '&times;'.html_safe, website, method: :delete, data: {
-  confirm: 'Are you sure you want to delete this website?'
-} %>
+<div>
+  <%= link_to website.title, website_path(website) if website.title %>
+  |
+  <%= link_to website.url, website.url, target: :_blank %>
+  |
+  <%= link_to '&times;'.html_safe, website, method: :delete, data: {
+    confirm: 'Are you sure you want to delete this website?'
+  } %>
+  <ul>
+    <% website.links.each do |link| %>
+      <li><%= render 'link', link: link %>
+    <% end %>
+  </ul>
+</div>

--- a/db/migrate/20160927212030_create_links.rb
+++ b/db/migrate/20160927212030_create_links.rb
@@ -1,0 +1,11 @@
+class CreateLinks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :links do |t|
+      t.string :text
+      t.string :href
+      t.references :website, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923130657) do
+ActiveRecord::Schema.define(version: 20160927212030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "links", force: :cascade do |t|
+    t.string   "text"
+    t.string   "href"
+    t.integer  "website_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["website_id"], name: "index_links_on_website_id", using: :btree
+  end
 
   create_table "websites", force: :cascade do |t|
     t.string   "url"
@@ -23,4 +32,5 @@ ActiveRecord::Schema.define(version: 20160923130657) do
     t.index ["url"], name: "index_websites_on_url", using: :btree
   end
 
+  add_foreign_key "links", "websites"
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Link, type: :model do
+  describe 'validations' do
+    it 'ensure a link has href' do
+      link = Link.new(href: nil)
+      link.save
+      expect(link.errors).to include(:href)
+    end
+    
+    it 'ensure a link has text' do
+      link = Link.new(text: nil)
+      link.save
+      expect(link.errors).to include(:text)
+    end
+  end
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Link, type: :model do
       link.save
       expect(link.errors).to include(:href)
     end
-    
+
     it 'ensure a link has text' do
       link = Link.new(text: nil)
       link.save

--- a/spec/services/website_scraper/link_adapter_spec.rb
+++ b/spec/services/website_scraper/link_adapter_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe WebsiteScraper::LinkAdapter do
+  let(:adapter) { WebsiteScraper::LinkAdapter.new(page_link) }
+
+  context 'when getting a links text' do
+    context 'and the text is fine' do
+      let(:page_link) { double('link', text: 'I have some text') }
+
+      it 'returns its text' do
+        expect(adapter.text).to eq('I have some text')
+      end
+    end
+
+    context 'and the text is blank-ish ' do
+      let(:page_link) { double('link', text: "    \n    ", resolved_uri: 'resolved_uri') }
+
+      it 'returns its resolved_uri instead' do
+        expect(adapter.text).to eq('resolved_uri')
+      end
+    end
+  end
+
+  context 'when getting a links href' do
+    context 'and the scheme is known' do
+      let(:page_link) { double('link', resolved_uri: 'http://codebikeandmore.com') }
+
+      it 'returns its absolute path' do
+        expect(adapter.href).to eq('http://codebikeandmore.com')
+      end
+    end
+
+    context 'and the scheme is not known' do
+      let(:page_link) { double('link', uri: 'http://codebikeandmore.com') }
+      before { allow(page_link).to receive(:resolved_uri).and_raise(Mechanize::UnsupportedSchemeError.new(nil, nil)) }
+
+      it 'returns its uri' do
+        expect(adapter.href).to eq('http://codebikeandmore.com')
+      end
+    end
+  end
+end

--- a/spec/services/website_scraper_spec.rb
+++ b/spec/services/website_scraper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 # NOTE: here I'd add VCR for better predicting specs and not perform Network
-# requests all the time
+# requests all the time. In the end, this is a mixture of unit and end to end specs.
 RSpec.describe WebsiteScraper do
   context 'with a valid url' do
     let(:website) { Website.new(url: 'http://codebikeandmore.com') }
@@ -9,6 +9,11 @@ RSpec.describe WebsiteScraper do
     it 'fills in the title attribute of a webiste' do
       complete_website = WebsiteScraper.new(website).go_get_it
       expect(complete_website.title).to eq('Code, Bike & More')
+    end
+
+    it 'fills in the links of a webiste' do
+      complete_website = WebsiteScraper.new(website).go_get_it
+      expect(complete_website.links).to_not be_empty
     end
   end
 

--- a/spec/views/api/v1/websites/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/websites/index.json.jbuilder_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'api/v1/websites/index' do
+  let(:websites) do
+    [
+      Website.create!(
+        url: 'http://codebikeandmore.com',
+        title: 'Code, Bike & More',
+        links: [ Link.new(href: 'http://fakelink.fake', text: 'I am fake') ]
+      ),
+      Website.create!(
+        url: 'http://google.com',
+        title: 'Google',
+        links: [ Link.new(href: 'http://anotherfakelink.fake', text: 'I am another fake') ]
+      )
+    ]
+  end
+
+  let(:parsed_response) { JSON.parse(render).with_indifferent_access }
+
+  before { assign(:websites, websites) }
+
+  it 'displays all the websites' do
+    expect(parsed_response[:websites].count).to eq(2)
+  end
+
+  describe 'the websites' do
+    it 'show their url' do
+      expect(parsed_response[:websites].first[:url]).to eq('http://codebikeandmore.com')
+      expect(parsed_response[:websites].last[:url]).to eq('http://google.com')
+    end
+
+    it 'show their title' do
+      expect(parsed_response[:websites].first[:title]).to eq('Code, Bike & More')
+      expect(parsed_response[:websites].last[:title]).to eq('Google')
+    end
+
+    describe 'show their links' do
+      it 'with their href' do
+        expect(parsed_response[:websites].first[:links].first[:href]).to eq('http://fakelink.fake')
+        expect(parsed_response[:websites].last[:links].first[:href]).to eq('http://anotherfakelink.fake')
+      end
+
+      it 'with their text' do
+        expect(parsed_response[:websites].first[:links].first[:text]).to eq('I am fake')
+        expect(parsed_response[:websites].last[:links].first[:text]).to eq('I am another fake')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add `Link` model.
- When scraping a website, gets its links. This requiring some adapting since due to, for example:
  - Invalid `scheme` (at least for `Mechanize`). Eg. `mailto:andresilveirah@gmail.com` is not recognised as valid. In these cases `WebScraper::LinkAdapter` will get its raw uri instead.
  - Relative paths. Some links have their `href` like `/products/1` instead of `http://webiste.com/products/1`
  - Sometimes, the content of a link (its text) is not a text but rather a picture. In this case we return its uri as well.
