### PR TITLE
Add headers to website

### DIFF
--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -1,8 +1,8 @@
 class Header < ApplicationRecord
   belongs_to :website
-  
-  HTML_TAGS = %w(h1 h2 h3)
-  
+
+  HTML_TAGS = %w(h1 h2 h3).freeze
+
   validates :tag, :text, presence: true
   validates :tag, inclusion: HTML_TAGS
 end

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -1,0 +1,8 @@
+class Header < ApplicationRecord
+  belongs_to :website
+  
+  HTML_TAGS = %w(h1 h2 h3)
+  
+  validates :tag, :text, presence: true
+  validates :tag, inclusion: HTML_TAGS
+end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -3,6 +3,7 @@ class Website < ApplicationRecord
   validate  :url_valid?
 
   has_many :links, dependent: :destroy
+  has_many :headers, dependent: :destroy
 
   private
 

--- a/app/services/website_scraper.rb
+++ b/app/services/website_scraper.rb
@@ -12,6 +12,7 @@ class WebsiteScraper
       page = @driver.get(website.url)
       fill_in_title(page)
       fill_in_links(page)
+      fill_in_headers(page)
     end
     website
   end
@@ -20,6 +21,14 @@ class WebsiteScraper
 
   def link_adapter_class
     WebsiteScraper::LinkAdapter
+  end
+
+  def header_adapter_class
+    WebsiteScraper::HeaderAdapter
+  end
+
+  def headers_to_search_for
+    Header::HTML_TAGS
   end
 
   def fill_in_title(page)
@@ -33,6 +42,13 @@ class WebsiteScraper
         text: link.text,
         href: link.href
       )
+    end
+  end
+
+  def fill_in_headers(page)
+    page.search(*headers_to_search_for).each do |page_header|
+      header_attributes = header_adapter_class.new(page_header).to_h
+      website.headers.build(header_attributes)
     end
   end
 end

--- a/app/services/website_scraper/header_adapter.rb
+++ b/app/services/website_scraper/header_adapter.rb
@@ -1,0 +1,19 @@
+class WebsiteScraper
+  class HeaderAdapter
+    def initialize(page_header)
+      @page_header = page_header
+    end
+
+    def text
+      @page_header.text.strip
+    end
+
+    def tag
+      @page_header.name
+    end
+
+    def to_h
+      { tag: tag, text: text }
+    end
+  end
+end

--- a/app/views/api/v1/websites/_headers.json.jbuilder
+++ b/app/views/api/v1/websites/_headers.json.jbuilder
@@ -1,0 +1,2 @@
+json.text header.text
+json.tag header.tag

--- a/app/views/api/v1/websites/index.json.jbuilder
+++ b/app/views/api/v1/websites/index.json.jbuilder
@@ -3,4 +3,5 @@ json.websites @websites do |website|
   json.url   website.url
 
   json.links website.links, partial: 'links', as: :link
+  json.headers website.headers, partial: 'headers', as: :header
 end

--- a/app/views/websites/_header.html.erb
+++ b/app/views/websites/_header.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag header.tag, "#{header.tag}. #{header.text}" %>

--- a/app/views/websites/_website.html.erb
+++ b/app/views/websites/_website.html.erb
@@ -11,4 +11,9 @@
       <li><%= render 'link', link: link %>
     <% end %>
   </ul>
+  <ul>
+    <% website.headers.each do |header| %>
+      <li><%= render 'header', header: header %>
+    <% end %>
+  </ul>
 </div>

--- a/db/migrate/20160928134114_create_headers.rb
+++ b/db/migrate/20160928134114_create_headers.rb
@@ -1,0 +1,11 @@
+class CreateHeaders < ActiveRecord::Migration[5.0]
+  def change
+    create_table :headers do |t|
+      t.string :tag
+      t.string :text
+      t.references :website, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927212030) do
+ActiveRecord::Schema.define(version: 20160928134114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "headers", force: :cascade do |t|
+    t.string   "tag"
+    t.string   "text"
+    t.integer  "website_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["website_id"], name: "index_headers_on_website_id", using: :btree
+  end
 
   create_table "links", force: :cascade do |t|
     t.string   "text"
@@ -32,5 +41,6 @@ ActiveRecord::Schema.define(version: 20160927212030) do
     t.index ["url"], name: "index_websites_on_url", using: :btree
   end
 
+  add_foreign_key "headers", "websites"
   add_foreign_key "links", "websites"
 end

--- a/spec/models/header_spec.rb
+++ b/spec/models/header_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Header, type: :model do
       header.save
       expect(header.errors).to include(:text)
     end
-    
+
     it 'ensures that the tag is known' do
       header = Header.new(tag: 'some weird tag')
       header.save

--- a/spec/models/header_spec.rb
+++ b/spec/models/header_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Header, type: :model do
+  describe 'validations' do
+    it 'ensure a header has tag' do
+      header = Header.new(tag: nil)
+      header.save
+      expect(header.errors).to include(:tag)
+    end
+
+    it 'ensure a header has text' do
+      header = Header.new(text: nil)
+      header.save
+      expect(header.errors).to include(:text)
+    end
+    
+    it 'ensures that the tag is known' do
+      header = Header.new(tag: 'some weird tag')
+      header.save
+      expect(header.errors).to include(:tag)
+    end
+  end
+end

--- a/spec/services/website_scraper/header_adapter_spec.rb
+++ b/spec/services/website_scraper/header_adapter_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe WebsiteScraper::HeaderAdapter do
+  let(:adapter) { WebsiteScraper::HeaderAdapter.new(page_header) }
+
+  context 'when getting a headers text' do
+    let(:page_header) { double('link', text: 'I have some text') }
+
+    it 'returns its text' do
+      expect(adapter.text).to eq('I have some text')
+    end
+  end
+
+  context 'when getting a headers tag' do
+    let(:page_header) { double('link', name: 'h1') }
+
+    it 'returns its [tag] name' do
+      expect(adapter.tag).to eq('h1')
+    end
+  end
+
+  describe '#to_h' do
+    let(:page_header) { double('link', name: 'h1', text: 'text') }
+
+    it 'returns a hash containing its tag and text' do
+      expect(adapter.to_h).to eq(tag: 'h1', text: 'text')
+    end
+  end
+end

--- a/spec/services/website_scraper_spec.rb
+++ b/spec/services/website_scraper_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe WebsiteScraper do
       complete_website = WebsiteScraper.new(website).go_get_it
       expect(complete_website.links).to_not be_empty
     end
+
+    it 'fills in the headers of a webiste' do
+      complete_website = WebsiteScraper.new(website).go_get_it
+      expect(complete_website.headers).to_not be_empty
+    end
   end
 
   context 'with a invalid url' do

--- a/spec/views/api/v1/websites/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/websites/index.json.jbuilder_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe 'api/v1/websites/index' do
       Website.create!(
         url: 'http://codebikeandmore.com',
         title: 'Code, Bike & More',
-        links: [ Link.new(href: 'http://fakelink.fake', text: 'I am fake') ]
+        links: [ Link.new(href: 'http://fakelink.fake', text: 'I am fake') ],
+        headers: [ Header.new(tag: 'h1', text: 'I am a header') ]
       ),
       Website.create!(
         url: 'http://google.com',
         title: 'Google',
-        links: [ Link.new(href: 'http://anotherfakelink.fake', text: 'I am another fake') ]
+        links: [ Link.new(href: 'http://anotherfakelink.fake', text: 'I am another fake') ],
+        headers: [ Header.new(tag: 'h2', text: 'I am another header') ]
       )
     ]
   end
@@ -44,6 +46,18 @@ RSpec.describe 'api/v1/websites/index' do
       it 'with their text' do
         expect(parsed_response[:websites].first[:links].first[:text]).to eq('I am fake')
         expect(parsed_response[:websites].last[:links].first[:text]).to eq('I am another fake')
+      end
+    end
+
+    describe 'show their headers' do
+      it 'with their tag' do
+        expect(parsed_response[:websites].first[:headers].first[:tag]).to eq('h1')
+        expect(parsed_response[:websites].last[:headers].first[:tag]).to eq('h2')
+      end
+
+      it 'with their text' do
+        expect(parsed_response[:websites].first[:headers].first[:text]).to eq('I am a header')
+        expect(parsed_response[:websites].last[:headers].first[:text]).to eq('I am another header')
       end
     end
   end


### PR DESCRIPTION
- Add `Header` model.
- When scraping a website, gets its headers.
- Even though the headers didn't need much adapting from `Nokogiri::Elements` to our own data model, I decided to implement the `WebsiteScraper::HeaderAdapter` to keep consistency and decoupling from `WebsiteScraper`.
